### PR TITLE
2 error on compile

### DIFF
--- a/list.c
+++ b/list.c
@@ -44,7 +44,7 @@ struct rs_rig *add_rig(rig_model_t model)
 
 void set_rig_port(struct rs_rig *rig, const char *portstr)
 {
-  strncpy(rig->rig->state.rigport.pathname, portstr, FILPATHLEN - 1);
+  strncpy(rig->rig->state.rigport.pathname, portstr, HAMLIB_FILPATHLEN - 1);
 }
 
 void set_rig_speed(struct rs_rig *rig, int speed)

--- a/main.c
+++ b/main.c
@@ -81,8 +81,8 @@ int xmain(int argc, char **argv)
   rigb = rig_init(modelb);
 
   riga->state.rigport.parm.serial.rate = RIG_A_SPEED;
-  strncpy(riga->state.rigport.pathname, RIG_A_PORT, FILPATHLEN - 1);
-  strncpy(rigb->state.rigport.pathname, RIG_B_PORT, FILPATHLEN - 1);
+  strncpy(riga->state.rigport.pathname, RIG_A_PORT, HAMLIB_FILPATHLEN - 1);
+  strncpy(rigb->state.rigport.pathname, RIG_B_PORT, HAMLIB_FILPATHLEN - 1);
 
   retval = rig_open(riga);
   if(retval != RIG_OK) { fprintf(stderr, "*** Could not open FT857.\n"); exit(1); }

--- a/rigsync.h
+++ b/rigsync.h
@@ -26,6 +26,11 @@
 // note Ubuntu 20.04 uses hamlib 3.3
 #include <hamlib/rig.h>
 
+// Hamlib 4.x renames FILEPATHLEN to HAMLIB_FILEPATHLEN
+#ifndef HAMLIB_FILPATHLEN
+#define HAMLIB_FILPATHLEN FILPATHLEN
+#endif
+
 struct rs_rig_state
 {
   freq_t freq;


### PR DESCRIPTION
Hamlib 4.x renames the FILPATHLEN macro to HAMLIB_FILPATHLEN.  This commit adds a test for the new macro in rigsync.h and and renames it in main.c and list.c.